### PR TITLE
Update evaluated-output datatype

### DIFF
--- a/data/config.yaml
+++ b/data/config.yaml
@@ -11,7 +11,7 @@
 # ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
 id: alvearie.fhir.ig
 canonical: http://ibm.com/fhir/cdm
-version: 0.1.0
+version: 1.0.0
 name: AlvearieFHIRImplementationGuide
 title: Alvearie FHIR Implementation Guide
 status: active

--- a/data/extensions/InsightDetailExtensions.fsh
+++ b/data/extensions/InsightDetailExtensions.fsh
@@ -12,8 +12,8 @@ Description:    "The break down of information referenced to produce the insight
 * extension[referencePath] ^definition = "Path to FHIR element in the reference that was used to produce the insight"
 
 * extension contains EvaluatedOutput named evaluatedOutput 0..1 
-* extension[reference] ^short = "Reference to content leveraged to produce the insight"
-* extension[reference] ^definition = "Reference to content leveraged to produce the insight"
+* extension[evaluatedOutput] ^short = "Attachment for content created as output when producing the insight"
+* extension[evaluatedOutput] ^definition = "Attachment for content created as output when producing the insight"
 
 * extension contains InsightResult named insightResult 0..*
 * extension[insightResult] ^short = "Value specific final insight results based on a particular piece of evaluated input."
@@ -34,5 +34,5 @@ Description:    "Path to FHIR element in the reference that was leveraged to pro
 Extension:      EvaluatedOutput
 Id:             evaluated-output
 Title:          "Evaluated Ouptut"
-Description:    "Reference to content produced while evaluating the insight."
-* value[x] only Reference
+Description:    "Attachment for content created as output when producing the insight."
+* value[x] only Attachment

--- a/data/package.json
+++ b/data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alvearie.fhir.ig",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "canonical": "http://ibm.com/fhir/cdm",
   "url": "http://ibm.com/fhir/cdm",
   "title": "Alvearie FHIR Implementation Guide",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alvearie.fhir.ig",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "canonical": "http://alvearie.github.io/alvearie-fhir-ig",
   "url": "http://alvearie.github.io/alvearie-fhir-ig",
   "title": "Alvearie FHIR Implementation Guide",

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.ibm.fhir.cdm</groupId>
   <artifactId>ig-common-data-model</artifactId>
-  <version>0.1.1-SNAPSHOT</version>
+  <version>${env.npm_package_version}-SNAPSHOT</version>
   <properties>
     <maven.compiler.source>1.7</maven.compiler.source>
     <maven.compiler.target>1.7</maven.compiler.target>


### PR DESCRIPTION
Also fixed the short and definition descriptive text for evaluated output to be associated appropriately to the evaluated-output extension in context of the InsightDetail